### PR TITLE
Implement simple topic and question pages

### DIFF
--- a/data/bible-verses.json
+++ b/data/bible-verses.json
@@ -1,0 +1,5 @@
+{
+  "Hope": ["Romans 8:24-25", "Psalm 42:6-7", "Isaiah 40:31"],
+  "Love": ["John 3:16", "1 Corinthians 13"],
+  "Forgiveness": ["Matthew 6:14", "1 John 1:9"]
+}

--- a/data/topics.json
+++ b/data/topics.json
@@ -1,0 +1,5 @@
+{"topics": [
+  {"id": "love", "name": "Love"},
+  {"id": "hope", "name": "Hope"},
+  {"id": "forgiveness", "name": "Forgiveness"}
+]}

--- a/pages/api/generate-questions.js
+++ b/pages/api/generate-questions.js
@@ -1,0 +1,23 @@
+import { Configuration, OpenAIApi } from 'openai'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+  const { topic } = req.body
+  const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY })
+  const openai = new OpenAIApi(configuration)
+  const prompt = `次のテーマ「${topic}」について、ディスカッション用の深掘り質問を3つ日本語で作成してください。ノンクリスチャンにも理解しやすい表現で。`
+  try {
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: prompt }]
+    })
+    const text = completion.data.choices[0].message.content
+    const questions = text.split('\n').filter(Boolean)
+    res.status(200).json({ questions })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ message: 'Failed to generate questions' })
+  }
+}

--- a/pages/topics/[id].js
+++ b/pages/topics/[id].js
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import fs from 'fs'
+import path from 'path'
+
+export async function getStaticPaths() {
+  const filePath = path.join(process.cwd(), 'data', 'topics.json');
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const paths = data.topics.map((t) => ({ params: { id: t.id } }));
+  return { paths, fallback: false };
+}
+
+export async function getStaticProps({ params }) {
+  const topicsPath = path.join(process.cwd(), 'data', 'topics.json');
+  const topicsData = JSON.parse(fs.readFileSync(topicsPath, 'utf8'));
+  const topic = topicsData.topics.find((t) => t.id === params.id);
+
+  const versesPath = path.join(process.cwd(), 'data', 'bible-verses.json');
+  const versesData = JSON.parse(fs.readFileSync(versesPath, 'utf8'));
+  const verses = versesData[topic.name] || [];
+
+  return { props: { topic, verses } };
+}
+
+export default function TopicDetail({ topic, verses }) {
+  const router = useRouter();
+  const [reason, setReason] = useState('');
+  const [questions, setQuestions] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const generateQuestions = async () => {
+    setLoading(true);
+    const res = await fetch('/api/generate-questions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topic: topic.name })
+    });
+    const data = await res.json();
+    setQuestions(data.questions || []);
+    setLoading(false);
+  };
+
+  return (
+    <div>
+      <button onClick={() => router.back()}>&lt; Back</button>
+      <h1>{topic.name}</h1>
+      <div>
+        <label>
+          Why did you choose this topic?
+          <input
+            type="text"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+          />
+        </label>
+        <button onClick={generateQuestions} disabled={loading}>
+          {loading ? 'Loading...' : 'Generate Questions'}
+        </button>
+      </div>
+      {questions.length > 0 && (
+        <div>
+          <h2>Questions</h2>
+          <ol>
+            {questions.map((q, i) => (
+              <li key={i}>{q}</li>
+            ))}
+          </ol>
+        </div>
+      )}
+      {verses.length > 0 && (
+        <div>
+          <h2>Bible Verses</h2>
+          <ul>
+            {verses.map((v, i) => (
+              <li key={i}>{v}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/topics/index.js
+++ b/pages/topics/index.js
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+import fs from 'fs'
+import path from 'path'
+
+export async function getStaticProps() {
+  const filePath = path.join(process.cwd(), 'data', 'topics.json');
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  return { props: { topics: data.topics } };
+}
+
+export default function TopicsPage({ topics }) {
+  return (
+    <div>
+      <h1>Topics</h1>
+      <ul>
+        {topics.map((topic) => (
+          <li key={topic.id}>
+            <Link href={`/topics/${topic.id}`}>{topic.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add static data for topics and Bible verses
- implement topics list page and detail page
- add API route to request GPT questions

## Testing
- `npm run test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483de4856083208739d350065b0809